### PR TITLE
Error en section__gallery pantalla mayor a 1500

### DIFF
--- a/assets/styles/desktop.css
+++ b/assets/styles/desktop.css
@@ -52,5 +52,5 @@ body{
 .section__gallery > img{
     width: 100%;
     max-width: 48rem;
-    height: 48rem;
+    /*height: 48rem;*/ <-
 }


### PR DESCRIPTION
Este `height` se interpone con la propiedad `flex` para expandir las imágenes.

Eliminar este `height`, hace que el flex llene de nuevo de izquierda a derecha. Pero la ultima imagen no se muestra con el alto del contenedor.